### PR TITLE
fix expected np.arctan2() exception for numpy 1.21

### DIFF
--- a/quantities/tests/test_umath.py
+++ b/quantities/tests/test_umath.py
@@ -226,7 +226,7 @@ class TestUmath(TestCase):
             np.arctan2(3*pq.V, 3*pq.V),
             np.radians(45)*pq.dimensionless
             )
-        self.assertRaises(ValueError, np.arctan2, (1*pq.m, 1*pq.m))
+        self.assertRaises((TypeError, ValueError), np.arctan2, (1*pq.m, 1*pq.m))
 
     def test_hypot(self):
         self.assertQuantityEqual(np.hypot(3 * pq.m, 4 * pq.m),  5 * pq.m)


### PR DESCRIPTION
NumPy 1.21 has changed the exception type for incorrect np.arctan2()
arguments from ValueError to TypeError.  Adjust the test appropriately.

Fixes #190